### PR TITLE
Vagrant user is the apache one now, also php7.1 does not appear

### DIFF
--- a/install_master_owncloud.sh
+++ b/install_master_owncloud.sh
@@ -1,9 +1,8 @@
 sudo rm -rf core
 git clone https://github.com/owncloud/core.git
-cd core
 fecha=`date +%d-%m-%y`
 sudo cp -r core "/var/www/html/master_$fecha"
-sudo chown -R www-data:www-data "/var/www/html/master_$fecha"
+sudo chown -R vagrant:www-data "/var/www/html/master_$fecha"
 cd "/var/www/html/master_$fecha"
-sudo -u www-data make
+make
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -24,7 +24,7 @@
        - { name: 'sudo' }
        - { name: 'apache2' }
        - { name: 'mysql-server' }
-       - { name: 'owncloud' }
+       - { name: 'owncloud-files' }
        - { name: 'npm' }
        - { name: 'nodejs-legacy' }
        - { name: 'php7.0' }

--- a/reboot_owncloud_installation.sh
+++ b/reboot_owncloud_installation.sh
@@ -15,7 +15,7 @@ mysql -u root -h localhost -e "drop database owncloud"
 mysql -u root -h localhost -e "drop user oc_admin"
 mysql -u root -h localhost -e "drop user oc_admin@localhost"
 
-sudo -u www-data $installation_path/occ maintenance:install --database='mysql' --database-name='owncloud' --database-user='root' --database-pass='' --admin-user='admin' --admin-pass='admin'
+$installation_path/occ maintenance:install --database='mysql' --database-name='owncloud' --database-user='root' --database-pass='' --admin-user='admin' --admin-pass='admin'
 
 IP_ADDRESS=$(ifconfig eth1 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://')
-sudo -u www-data $installation_path/occ config:system:set trusted_domains 2 --value=$IP_ADDRESS
+$installation_path/occ config:system:set trusted_domains 2 --value=$IP_ADDRESS


### PR DESCRIPTION
Some fixes to develop owncloud using new makefile in 10.0.

Vagrant user is now the apache user to run tests.

php7.1 is not installed anymore. It was installed with owncloud package somehow (?).